### PR TITLE
Fixes foreign key errors in seed data

### DIFF
--- a/routes/post.js
+++ b/routes/post.js
@@ -53,6 +53,7 @@ app.post('/popular', (request, response) => {
 // Searches
 app.post('/search', (request, response) => {
     const search = request.body.search;
+    const {orderBy} = req.query;
     
     Post.fetchSearch(search)
         .then(res => response.status(200).json(res))

--- a/seeds/01-users.js
+++ b/seeds/01-users.js
@@ -6,9 +6,9 @@ exports.seed = function(knex) {
       .then(function () {
         // Inserts seed entries
         return knex('users').insert([
-          {email: 'email1@email.com', display_name:'admin', profile_picture: image, track:'web', likes: 0, onboarded:false},
-          {email: 'email2@email.com', display_name:'mod', profile_picture: image, track:'web', likes:0, onboarded:false},
-          {email: 'email3@email.com', display_name:'user', profile_picture: image, track:'web', likes:0, onboarded:false}
+          {id: 1, email: 'email1@email.com', display_name:'admin', profile_picture: image, track:'web', likes: 0, onboarded:false},
+          {id: 2, email: 'email2@email.com', display_name:'mod', profile_picture: image, track:'web', likes:0, onboarded:false},
+          {id: 3, email: 'email3@email.com', display_name:'user', profile_picture: image, track:'web', likes:0, onboarded:false}
         ]);
       });
   };

--- a/seeds/01a-rooms.js
+++ b/seeds/01a-rooms.js
@@ -1,6 +1,6 @@
 exports.seed = function(knex) {
   // Deletes ALL existing entries
-  return knex('rooms').del()
+  return knex.schema.raw('TRUNCATE TABLE rooms CASCADE')
     .then(function () {
       // Inserts seed entries
       return knex('rooms').insert([

--- a/seeds/02-posts.js
+++ b/seeds/02-posts.js
@@ -1,12 +1,14 @@
 exports.seed = function(knex) {
   // Deletes ALL existing entries
   return knex('posts').del()
-    .then(function () {
+    .then(async function () {
       // Inserts seed entries
+      const defaultRoom = await knex("rooms").first();
+      console.log(defaultRoom)
       return knex('posts').insert([
-        {user_id: 1, question:'jar gonj ar gon ja', answer:'jar gonj ar gon jajar gonj ar gon jajar gonj ar gon ja', likes:0, comments:0, track:0},
-        {user_id: 2, question:'jar gonj ar gon ja', answer:'jar gonj ar gon jajar gonj ar gon jajar gonj ar gon ja', likes:0, comments:0, track:0},
-        {user_id: 3, question:'jar gonj ar gon ja', answer:'jar gonj ar gon jajar gonj ar gon jajar gonj ar gon ja', likes:0, comments:0, track:0}
+        {user_id: 1, question:'jar gonj ar gon ja', answer:'jar gonj ar gon jajar gonj ar gon jajar gonj ar gon ja', likes:0, comments:0, track:0, room_id: defaultRoom.id},
+        {user_id: 2, question:'jar gonj ar gon ja', answer:'jar gonj ar gon jajar gonj ar gon jajar gonj ar gon ja', likes:0, comments:0, track:0, room_id: defaultRoom.id},
+        {user_id: 3, question:'jar gonj ar gon ja', answer:'jar gonj ar gon jajar gonj ar gon jajar gonj ar gon ja', likes:0, comments:0, track:0, room_id: defaultRoom.id}
       ]);
     });
 };

--- a/seeds/03-comments.js
+++ b/seeds/03-comments.js
@@ -1,12 +1,13 @@
 exports.seed = function(knex) {
   // Deletes ALL existing entries
   return knex('comments').del()
-    .then(function () {
+    .then(async function () {
       // Inserts seed entries
+      const post = await knex("posts").first();
       return knex('comments').insert([
-        {user_id: 1, post_id: 1, comment: 'Admin Comment', likes:0},
-        {user_id: 2, post_id: 1, comment: 'Mod Comment', likes:0},
-        {user_id: 3, post_id: 1, comment: 'User Comment', likes:0}
+        {user_id: 1, post_id: post.id, comment: 'Admin Comment', likes:0},
+        {user_id: 2, post_id: post.id, comment: 'Mod Comment', likes:0},
+        {user_id: 3, post_id: post.id, comment: 'User Comment', likes:0}
       ]);
     });
 };

--- a/seeds/05-roles.js
+++ b/seeds/05-roles.js
@@ -1,12 +1,13 @@
 exports.seed = function(knex) {
   // Deletes ALL existing entries
   return knex('roles').del()
-    .then(function () {
+    .then(async function () {
       // Inserts seed entries
+      const permissions = await knex("permissions");
       return knex('roles').insert([
-        {name: 'admin', permission_id: 1},
-        {name: 'moderator', permission_id: 2},
-        {name: 'alumni', permission_id: 3}       
+        {name: 'admin', permission_id: permissions[0].id},
+        {name: 'moderator', permission_id: permissions[1].id},
+        {name: 'alumni', permission_id: permissions[2].id}       
       ]);
     });
 };

--- a/seeds/06-user_roles.js
+++ b/seeds/06-user_roles.js
@@ -2,12 +2,13 @@
 exports.seed = function(knex) {
   // Deletes ALL existing entries
   return knex('user_roles').del()
-    .then(function () {
+    .then(async function () {
       // Inserts seed entries
+      const roles = await knex("roles");
       return knex('user_roles').insert([
-        {user_id: 1, role_id: 1},
-        {user_id: 2, role_id: 2},
-        {user_id: 3, role_id: 3},
+        {user_id: 1, role_id: roles[0].id},
+        {user_id: 2, role_id: roles[1].id},
+        {user_id: 3, role_id: roles[2].id},
       ]);
     });
 };


### PR DESCRIPTION
# LAN-B PR Template 
Trello Card URL : N/A

# Description of changes: 
The seed files would give errors after they were initially ran. This is because the foreign key relationships were dependent on other seed data, so when the other records were deleted the foreign keys no longer referenced any real records. The seeds were updated to dynamically get the appropriate id's for their foreign key relationships.

## How was it tested? 
manually tested in TablePlus and pgAdmin.

## PR Checklist: 

✅  Code follows project guidelines
✅  Self reviewed / peer reviewed 
✅  New warnings fixed
✅  Atomic commits 
✅  Removed debug code
✅  No merge conflicts 